### PR TITLE
Fix comics tag response validation

### DIFF
--- a/XKCD.ipynb
+++ b/XKCD.ipynb
@@ -386,7 +386,7 @@
     "            }\n",
     "            comics_tag = createThought(comics_model)\n",
     "            comics_tag_id = comics_tag.json()\n",
-    "        elif process_response(parent):     \n",
+    "        elif process_response(comics_tag):     \n",
     "            comics_tag_id = comics_tag.json()['id']\n",
     "        print(\"Comics Tag: \" + comics_tag_id)\n",
     "        addLink(from_id=comics_tag_id,to_id=new_id,relation=1)\n",


### PR DESCRIPTION
## Summary
- Validate comics tag API response instead of parent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b51f8f1ab483258611059b94f8ced2