### PR TITLE
Handle unknown request types in get()

### DIFF
--- a/BrainAPI.ipynb
+++ b/BrainAPI.ipynb
@@ -109,6 +109,7 @@
     "        if verbose: print(\"You chose Get Note in markdown\")\n",
     "    else:\n",
     "        print(\"Invalid Type.\")\n",
+    "        raise ValueError(f\"Unknown request type: {type}\")\n",
     "    url = baseUrl + addURL\n",
     "    if verbose: print(url)\n",
     "    return requests.get(url, headers=get_headers)\n",

--- a/XKCD.ipynb
+++ b/XKCD.ipynb
@@ -116,6 +116,7 @@
     "        if verbose: print(\"You chose Get Note in markdown\")\n",
     "    else:\n",
     "        print(\"Invalid Type.\")\n",
+    "        raise ValueError(f\"Unknown request type: {type}\")\n",
     "    url = baseUrl + addURL\n",
     "    if verbose: print(url)\n",
     "    return requests.get(url, headers=get_headers)\n",


### PR DESCRIPTION
## Summary
- Raise a ValueError for unrecognized request types
- Prevent constructing a URL for unknown types in get()

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b5232f91388325b699ee05b80d6acf