### PR TITLE
Add global verbose flag to BrainAPI notebook

### DIFF
--- a/BrainAPI.ipynb
+++ b/BrainAPI.ipynb
@@ -20,6 +20,7 @@
     "import requests\n",
     "from json import JSONDecodeError\n",
     "\n",
+    "verbose = False\n",
     "api_path = 'APIKey.txt'\n",
     " # The following ID is a read-only public brain for testing. The Bard.\n",
     " # Only read-only calls will work on TheBard\n",


### PR DESCRIPTION
## Summary
- define global `verbose = False` after module imports
- rely on this global flag in subsequent cells for optional logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b62a867e088325bb91a3d47a9b84a3