### PR TITLE
chore: remove unused data parameter from get helper

### DIFF
--- a/BrainAPI.ipynb
+++ b/BrainAPI.ipynb
@@ -71,7 +71,7 @@
     "from urllib.parse import quote\n",
     "\n",
     "# This is the main \"switchboard\" get function.\n",
-    "def get(type,data=None, search=\"\", results=30, target=None, nameOnly=True):\n",
+    "def get(type, search=\"\", results=30, target=None, nameOnly=True):\n",
     "    if target is None:\n",
     "        target = homeThought\n",
     "    get_headers = {\"Content-Type\": \"application/json\", 'Authorization': f'Bearer {apiKey}', 'Krang-Version': '2020-06-10'}\n",

--- a/XKCD.ipynb
+++ b/XKCD.ipynb
@@ -77,7 +77,7 @@
     "from json import JSONDecodeError\n",
     "\n",
     "# This is the main \"switchboard\" get function.\n",
-    "def get(type,data=None, search=\"\", results=30, target=None, nameOnly=True):\n",
+    "def get(type, search=\"\", results=30, target=None, nameOnly=True):\n",
     "    if target is None:\n",
     "        target = homeThought\n",
     "    get_headers = {\"Content-Type\": \"application/json\", 'Authorization': f'Bearer {apiKey}', 'Krang-Version': '2020-06-10'}\n",


### PR DESCRIPTION
## Summary
- remove unused `data` parameter from `get` function in BrainAPI and XKCD notebooks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b62cfc5e5c8325806673407c65a848